### PR TITLE
Support sgptrc config and global role/function search paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ https://github.com/TheR1D/shell_gpt/assets/16740832/9197283c-db6a-4b46-bfea-3eb7
 ```shell
 pip install shell-gpt
 ```
-By default, ShellGPT uses OpenAI's API and GPT-4 model. You'll need an API key, you can generate one [here](https://beta.openai.com/account/api-keys). You will be prompted for your key which will then be stored in `~/.config/shell_gpt/.sgptrc`. A system-wide configuration file located at `/etc/shell_gpt/.sgptrc` is also supported, and any settings in the user file override the system defaults. OpenAI API is not free of charge, please refer to the [OpenAI pricing](https://openai.com/pricing) for more information.
+By default, ShellGPT uses OpenAI's API and GPT-4 model. You'll need an API key, you can generate one [here](https://beta.openai.com/account/api-keys). You will be prompted for your key which will then be stored in `~/.config/shell_gpt/sgptrc` (or `.sgptrc` for backwards compatibility). A system-wide configuration file located at `/etc/shell_gpt/sgptrc` is also supported, and any settings in the user file override the system defaults. OpenAI API is not free of charge, please refer to the [OpenAI pricing](https://openai.com/pricing) for more information.
 
 > [!TIP]
 > Alternatively, you can use locally hosted open source models which are available for free. To use local models, you will need to run your own LLM backend server such as [Ollama](https://github.com/ollama/ollama). To set up ShellGPT with Ollama, please follow this comprehensive [guide](https://github.com/TheR1D/shell_gpt/wiki/Ollama).
@@ -378,7 +378,8 @@ Next time, same exact query will get results from local cache instantly. Note th
 This is just some examples of what we can do using OpenAI GPT models, I'm sure you will find it useful for your specific use cases.
 
 ### Runtime configuration file
-You can set up parameters in a runtime configuration file. System-wide defaults can be placed in `/etc/shell_gpt/.sgptrc`, while per-user overrides live in `~/.config/shell_gpt/.sgptrc`:
+You can set up parameters in a runtime configuration file. System-wide defaults can be placed in `/etc/shell_gpt/sgptrc`, while per-user overrides live in `~/.config/shell_gpt/sgptrc`:
+Paths inside configuration files may use `~` to refer to the current user's home directory.
 ```text
 # API key, also it is possible to define OPENAI_API_KEY env.
 OPENAI_API_KEY=your_api_key
@@ -386,8 +387,8 @@ OPENAI_API_KEY=your_api_key
 API_BASE_URL=default
 # Prettify markdown output.
 PRETTIFY_MARKDOWN=true
-# Path to a directory with role definitions.
-ROLE_STORAGE_PATH=/Users/user/.config/shell_gpt/roles
+# Path(s) to directories with role definitions.
+ROLE_STORAGE_PATH=/Users/user/.config/shell_gpt/roles:/etc/shell_gpt/roles
 # Max amount of cached message per chat session.
 CHAT_CACHE_LENGTH=100
 # Chat cache folder.
@@ -414,8 +415,8 @@ CODE_THEME=default
 OS_NAME=auto
 # Override detected shell in prompts.
 SHELL_NAME=auto
-# Path to a directory with functions.
-OPENAI_FUNCTIONS_PATH=/Users/user/.config/shell_gpt/functions
+# Path(s) to directories with functions.
+OPENAI_FUNCTIONS_PATH=/Users/user/.config/shell_gpt/functions:/etc/shell_gpt/functions
 # Print output of functions when LLM uses them.
 SHOW_FUNCTIONS_OUTPUT=false
 # Allows LLM to use functions.

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -241,13 +241,16 @@ def main(
     session: PromptSession[str] = PromptSession()
 
     while shell and interaction:
-        option = typer.prompt(
-            text="[E]xecute, [M]odify, [D]escribe, [A]bort",
-            type=Choice(("e", "m", "d", "a", "y"), case_sensitive=False),
-            default="e" if cfg.get("DEFAULT_EXECUTE_SHELL_CMD") == "true" else "a",
-            show_choices=False,
-            show_default=False,
-        )
+        try:
+            option = typer.prompt(
+                text="[E]xecute, [M]odify, [D]escribe, [A]bort",
+                type=Choice(("e", "m", "d", "a", "y"), case_sensitive=False),
+                default="e" if cfg.get("DEFAULT_EXECUTE_SHELL_CMD") == "true" else "a",
+                show_choices=False,
+                show_default=False,
+            )
+        except typer.Abort:
+            break
         if option in ("e", "y"):
             # "y" option is for keeping compatibility with old version.
             run_command(full_completion)

--- a/sgpt/llm_functions/init_functions.py
+++ b/sgpt/llm_functions/init_functions.py
@@ -3,11 +3,12 @@ import platform
 import shutil
 from pathlib import Path
 from typing import Any
+from os import pathsep
 
 from ..config import cfg
 from ..utils import option_callback
 
-FUNCTIONS_FOLDER = Path(cfg.get("OPENAI_FUNCTIONS_PATH"))
+FUNCTIONS_FOLDER = Path(cfg.get("OPENAI_FUNCTIONS_PATH").split(pathsep)[0])
 
 
 @option_callback
@@ -15,6 +16,7 @@ def install_functions(*_args: Any) -> None:
     current_folder = os.path.dirname(os.path.abspath(__file__))
     common_folder = Path(current_folder + "/common")
     common_files = [Path(path) for path in common_folder.glob("*.py")]
+    FUNCTIONS_FOLDER.mkdir(parents=True, exist_ok=True)
     print("Installing default functions...")
 
     for file in common_files:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+import os
+
 from sgpt.config import Config, DEFAULT_CONFIG
 
 
@@ -7,7 +9,7 @@ def test_system_config_overridden_by_local(tmp_path, monkeypatch):
 
     local_dir = tmp_path / "user"
     local_dir.mkdir()
-    local_cfg = local_dir / ".sgptrc"
+    local_cfg = local_dir / "sgptrc"
     local_cfg.write_text("DEFAULT_MODEL=gpt-4\n")
 
     monkeypatch.setenv("OPENAI_API_KEY", "test")
@@ -15,3 +17,27 @@ def test_system_config_overridden_by_local(tmp_path, monkeypatch):
 
     assert cfg.get("DEFAULT_MODEL") == "gpt-4"
     assert cfg.get("FOO") == "bar"
+
+
+def test_no_local_config_when_system_exists(tmp_path, monkeypatch):
+    system_cfg = tmp_path / "system.sgptrc"
+    system_cfg.write_text("DEFAULT_MODEL=gpt-3.5\n")
+
+    local_cfg = tmp_path / "sgptrc"
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    Config(local_cfg, system_config_path=system_cfg, **DEFAULT_CONFIG)
+
+    assert not local_cfg.exists()
+
+
+def test_expanduser(tmp_path, monkeypatch):
+    system_cfg = tmp_path / "system.sgptrc"
+    system_cfg.write_text("FOO=~/bar\n")
+
+    local_cfg = tmp_path / "sgptrc"
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    cfg = Config(local_cfg, system_config_path=system_cfg, **DEFAULT_CONFIG)
+
+    assert cfg.get("FOO") == os.path.expanduser("~/bar")


### PR DESCRIPTION
## Summary
- Allow configuration files named `sgptrc` or `.sgptrc` and avoid creating a user config when a global one exists
- Expand `~` in config values and search multiple directories for roles and functions
- Document new config file names and multi-path role/function lookup

## Testing
- `OPENAI_API_KEY=test pytest -q` *(fails: Aborted.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ecd9a9348332a8f6b6b46128123f