### PR TITLE
feat: add interactive model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ pip install shell-gpt
 ```
 By default, ShellGPT uses OpenAI's API and GPT-4 model. You'll need an API key, you can generate one [here](https://beta.openai.com/account/api-keys). You will be prompted for your key which will then be stored in `~/.config/shell_gpt/sgptrc` (or `.sgptrc` for backwards compatibility). A system-wide configuration file located at `/etc/shell_gpt/sgptrc` is also supported, and any settings in the user file override the system defaults. OpenAI API is not free of charge, please refer to the [OpenAI pricing](https://openai.com/pricing) for more information.
 
+If the configured model is unavailable, or you run `sgpt` with `--model ask`, ShellGPT queries the OpenAI models endpoint and lets you choose an available model. The chosen model is stored as your new default.
+
 > [!TIP]
 > Alternatively, you can use locally hosted open source models which are available for free. To use local models, you will need to run your own LLM backend server such as [Ollama](https://github.com/ollama/ollama). To set up ShellGPT with Ollama, please follow this comprehensive [guide](https://github.com/TheR1D/shell_gpt/wiki/Ollama).
 >
@@ -399,7 +401,7 @@ CACHE_LENGTH=100
 CACHE_PATH=/tmp/shell_gpt/cache
 # Request timeout in seconds.
 REQUEST_TIMEOUT=60
-# Default OpenAI model to use.
+# Default OpenAI model to use. Set to "ask" to select interactively.
 DEFAULT_MODEL=gpt-4o
 # Default color for shell and code completions.
 DEFAULT_COLOR=magenta
@@ -433,7 +435,8 @@ Possible options for `CODE_THEME`: https://pygments.org/styles/
 │   prompt      [PROMPT]  The prompt to generate completions for.                                          │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ --model            TEXT                       Large language model to use. [default: gpt-4o]             │
+│ --model            TEXT                       Large language model to use. Use 'ask' to choose           │
+│                                             interactively. [default: gpt-4o]                            │
 │ --temperature      FLOAT RANGE [0.0<=x<=2.0]  Randomness of generated output. [default: 0.0]             │
 │ --top-p            FLOAT RANGE [0.0<=x<=1.0]  Limits highest probable tokens (words). [default: 1.0]     │
 │ --md             --no-md                      Prettify markdown output. [default: md]                    │

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -17,6 +17,7 @@ from sgpt.handlers.repl_handler import ReplHandler
 from sgpt.llm_functions.init_functions import install_functions as inst_funcs
 from sgpt.role import DefaultRoles, SystemRole
 from sgpt.utils import (
+    ask_for_model,
     get_edited_prompt,
     get_sgpt_version,
     install_shell_integration,
@@ -32,7 +33,7 @@ def main(
     ),
     model: str = typer.Option(
         cfg.get("DEFAULT_MODEL"),
-        help="Large language model to use.",
+        help="Large language model to use. Use 'ask' to choose interactively.",
     ),
     temperature: float = typer.Option(
         0.0,
@@ -200,6 +201,9 @@ def main(
     if editor:
         prompt = get_edited_prompt()
 
+    if model == "ask":
+        model = ask_for_model()
+
     role_class = (
         DefaultRoles.check_get(shell, describe_shell, code)
         if not role
@@ -238,6 +242,7 @@ def main(
             functions=function_schemas,
         )
 
+    model = cfg.get("DEFAULT_MODEL")
     session: PromptSession[str] = PromptSession()
 
     while shell and interaction:

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -1,0 +1,38 @@
+from sgpt.config import Config, DEFAULT_CONFIG
+from sgpt.utils import ask_for_model
+
+
+def test_ask_for_model_updates_config(tmp_path, monkeypatch):
+    config_path = tmp_path / "sgptrc"
+    test_cfg = Config(
+        config_path,
+        system_config_path=None,
+        **{**DEFAULT_CONFIG, "OPENAI_API_KEY": "test"},
+    )
+    monkeypatch.setattr("sgpt.utils.cfg", test_cfg)
+
+    class DummyClient:
+        class Models:
+            def list(self):  # noqa: D401 - docstring not required
+                return type(
+                    "R",
+                    (),
+                    {
+                        "data": [
+                            type("M", (), {"id": "m1"}),
+                            type("M", (), {"id": "m2"}),
+                        ]
+                    },
+                )()
+
+        models = Models()
+
+    monkeypatch.setattr("sgpt.utils.OpenAI", lambda **_: DummyClient())
+    monkeypatch.setattr("sgpt.utils.typer.prompt", lambda *a, **k: 2)
+    monkeypatch.setattr("sgpt.utils.typer.echo", lambda *a, **k: None)
+
+    selected = ask_for_model()
+
+    assert selected == "m2"
+    assert test_cfg.get("DEFAULT_MODEL") == "m2"
+    assert "DEFAULT_MODEL=m2" in config_path.read_text()


### PR DESCRIPTION
## Summary
- prompt user to choose a model when --model ask is used
- recover from missing models by querying OpenAI models API
- document interactive model selection and add tests

## Testing
- `pytest` *(fails: assertion and role lookup issues)*
- `OPENAI_API_KEY=dummy pytest tests/test_model_selection.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68b1ca4db8e4833290fb428bfdd9dc3d