### PR TITLE
Avoid rewriting config when updating model

### DIFF
--- a/sgpt/utils.py
+++ b/sgpt/utils.py
@@ -119,5 +119,5 @@ def select_model() -> str:
     if selected not in [m.id for m in models]:
         raise UsageError("Invalid model selected")
     cfg["DEFAULT_MODEL"] = selected
-    cfg._write()
+    cfg._write(["DEFAULT_MODEL"])
     return selected

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,3 +41,19 @@ def test_expanduser(tmp_path, monkeypatch):
     cfg = Config(local_cfg, system_config_path=system_cfg, **DEFAULT_CONFIG)
 
     assert cfg.get("FOO") == os.path.expanduser("~/bar")
+
+
+def test_write_updates_only_specified_keys(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "sgptrc"
+    cfg_path.write_text("OPENAI_API_KEY=test\n")
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    cfg = Config(cfg_path, **{"DEFAULT_MODEL": "gpt-4o"})
+    cfg["CACHE_LENGTH"] = "1234"
+    cfg["DEFAULT_MODEL"] = "gpt-3.5"
+    cfg._write(["DEFAULT_MODEL"])
+
+    content = cfg_path.read_text()
+    assert "CACHE_LENGTH" not in content
+    assert "DEFAULT_MODEL=gpt-3.5" in content
+    assert "OPENAI_API_KEY=test" in content


### PR DESCRIPTION
## Summary
- allow Config._write to update only specific keys rather than rewriting full configuration
- persist only the selected model in user config when choosing a model
- test that _write does not add unrelated defaults

## Testing
- `OPENAI_API_KEY=test SHELL_INTERACTION=true pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1d64c22e083328ee253d5c0e34bf8