### PR TITLE
Allow configuring default system role

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ LLM might execute destructive commands, so please use it at your own risk❗️
 
 ### Roles
 ShellGPT allows you to create custom roles, which can be utilized to generate code, shell commands, or to fulfill your specific needs. To create a new role, use the `--create-role` option followed by the role name. You will be prompted to provide a description for the role, along with other details. This will create a JSON file in `~/.config/shell_gpt/roles` with the role name. Inside this directory, you can also edit default `sgpt` roles, such as **shell**, **code**, and **default**. Use the `--list-roles` option to list all available roles, and the `--show-role` option to display the details of a specific role. Here's an example of a custom role:
+
+To make one of your roles the default when no role flag is supplied, set `DEFAULT_SYSTEM_ROLE` in your configuration file (or the corresponding environment variable) to the desired role name.
 ```shell
 sgpt --create-role json_generator
 # Enter role description: Provide only valid json as response.
@@ -389,6 +391,8 @@ API_BASE_URL=default
 PRETTIFY_MARKDOWN=true
 # Path(s) to directories with role definitions.
 ROLE_STORAGE_PATH=/Users/user/.config/shell_gpt/roles:/etc/shell_gpt/roles
+# Default role used when no role-specific flags are provided.
+DEFAULT_SYSTEM_ROLE=ShellGPT
 # Max amount of cached message per chat session.
 CHAT_CACHE_LENGTH=100
 # Chat cache folder.

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -42,6 +42,7 @@ DEFAULT_CONFIG = {
         "ROLE_STORAGE_PATH",
         os.pathsep.join([str(ROLE_STORAGE_PATH), str(SYSTEM_ROLE_STORAGE_PATH)]),
     ),
+    "DEFAULT_SYSTEM_ROLE": os.getenv("DEFAULT_SYSTEM_ROLE", "ShellGPT"),
     "DEFAULT_EXECUTE_SHELL_CMD": os.getenv("DEFAULT_EXECUTE_SHELL_CMD", "false"),
     "DISABLE_STREAMING": os.getenv("DISABLE_STREAMING", "false"),
     "CODE_THEME": os.getenv("CODE_THEME", "dracula"),

--- a/sgpt/handlers/chat_handler.py
+++ b/sgpt/handlers/chat_handler.py
@@ -154,7 +154,7 @@ class ChatHandler(Handler):
                 raise BadArgumentUsage(
                     f'Could not determine chat role of "{self.chat_id}"'
                 )
-            if self.role.name == DefaultRoles.DEFAULT.value:
+            if self.role.name == DefaultRoles.default_role_name():
                 # If user didn't pass chat mode, we will use the one that was used to initiate the chat.
                 self.role = SystemRole.get(chat_role_name)
             else:

--- a/sgpt/role.py
+++ b/sgpt/role.py
@@ -181,9 +181,21 @@ class DefaultRoles(Enum):
             return SystemRole.get(DefaultRoles.DESCRIBE_SHELL.value)
         if code:
             return SystemRole.get(DefaultRoles.CODE.value)
-        return SystemRole.get(DefaultRoles.DEFAULT.value)
+        return cls.default_role()
+
+    @classmethod
+    def default_role_name(cls) -> str:
+        configured = cfg.get("DEFAULT_SYSTEM_ROLE")
+        name = configured.strip()
+        return name or cls.DEFAULT.value
+
+    @classmethod
+    def default_role(cls) -> SystemRole:
+        return SystemRole.get(cls.default_role_name())
 
     def get_role(self) -> SystemRole:
+        if self is DefaultRoles.DEFAULT:
+            return self.default_role()
         return SystemRole.get(self.value)
 
 

--- a/tests/_integration.py
+++ b/tests/_integration.py
@@ -22,7 +22,7 @@ from sgpt.__version__ import __version__
 from sgpt.app import main
 from sgpt.config import cfg
 from sgpt.handlers.handler import Handler
-from sgpt.role import SystemRole
+from sgpt.role import DefaultRoles
 
 runner = CliRunner()
 app = typer.Typer()
@@ -399,7 +399,7 @@ class TestShellGpt(TestCase):
 
     def test_color_output(self):
         color = cfg.get("DEFAULT_COLOR")
-        role = SystemRole.get("ShellGPT")
+        role = DefaultRoles.default_role()
         handler = Handler(role=role)
         assert handler.color == color
         os.environ["DEFAULT_COLOR"] = "red"

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -6,17 +6,26 @@ from typer.testing import CliRunner
 
 from sgpt import config, main
 from sgpt.__version__ import __version__
-from sgpt.role import DefaultRoles, SystemRole
+from sgpt.role import DefaultRoles
 
 from .utils import app, cmd_args, comp_args, mock_comp, runner
 
-role = SystemRole.get(DefaultRoles.DEFAULT.value)
 cfg = config.cfg
+
+
+def test_default_role_override(monkeypatch):
+    monkeypatch.setenv("DEFAULT_SYSTEM_ROLE", DefaultRoles.CODE.value)
+
+    role = DefaultRoles.default_role()
+
+    assert DefaultRoles.default_role_name() == DefaultRoles.CODE.value
+    assert role.name == DefaultRoles.CODE.value
 
 
 @patch("sgpt.handlers.handler.completion")
 def test_default(completion):
     completion.return_value = mock_comp("Prague")
+    role = DefaultRoles.default_role()
 
     args = {"prompt": "capital of the Czech Republic?"}
     result = runner.invoke(app, cmd_args(**args))
@@ -29,6 +38,7 @@ def test_default(completion):
 @patch("sgpt.handlers.handler.completion")
 def test_default_stdin(completion):
     completion.return_value = mock_comp("Prague")
+    role = DefaultRoles.default_role()
 
     stdin = "capital of the Czech Republic?"
     result = runner.invoke(app, cmd_args(), input=stdin)
@@ -81,6 +91,7 @@ def test_default_chat(completion):
     chat_name = "_test"
     chat_path = Path(cfg.get("CHAT_CACHE_PATH")) / chat_name
     chat_path.unlink(missing_ok=True)
+    role = DefaultRoles.default_role()
 
     args = {"prompt": "my number is 2", "--chat": chat_name}
     result = runner.invoke(app, cmd_args(**args))
@@ -133,6 +144,7 @@ def test_default_repl(completion):
     chat_name = "_test"
     chat_path = Path(cfg.get("CHAT_CACHE_PATH")) / chat_name
     chat_path.unlink(missing_ok=True)
+    role = DefaultRoles.default_role()
 
     args = {"--repl": chat_name}
     inputs = ["__sgpt__eof__", "my number is 6", "my number + 2?", "exit()"]
@@ -162,6 +174,7 @@ def test_default_repl_stdin(completion):
     chat_name = "_test"
     chat_path = Path(cfg.get("CHAT_CACHE_PATH")) / chat_name
     chat_path.unlink(missing_ok=True)
+    role = DefaultRoles.default_role()
 
     my_runner = CliRunner()
     my_app = typer.Typer()
@@ -193,6 +206,7 @@ def test_default_repl_stdin(completion):
 @patch("sgpt.handlers.handler.completion")
 def test_llm_options(completion):
     completion.return_value = mock_comp("Berlin")
+    role = DefaultRoles.default_role()
 
     args = {
         "prompt": "capital of the Germany?",


### PR DESCRIPTION
## Summary
- add a `DEFAULT_SYSTEM_ROLE` option to the runtime configuration and expose helpers for retrieving the configured role
- update handlers, tests, and integration helpers to respect the configured default role
- document how to override the default role in the README

## Testing
- OPENAI_API_KEY=dummy pytest tests/test_default.py
- OPENAI_API_KEY=dummy pytest tests/test_config.py

------
https://chatgpt.com/codex/tasks/task_e_68c9b7359c3c8332b7bdf2e3f2666bab